### PR TITLE
Handle SPIFFS metadata more elegantly

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -14,6 +14,9 @@ COMPONENT_INCDIRS := \
 	src/include \
 	src/Arch/$(SMING_ARCH)/include
 
+# Defined in spiffs Component
+COMPONENT_RELINK_VARS += SPIFFS_OBJ_META_LEN
+COMPONENT_CXXFLAGS += -DSPIFFS_OBJ_META_LEN=$(SPIFFS_OBJ_META_LEN)
 
 ##@Building
 

--- a/src/Arch/Host/FileSystem.cpp
+++ b/src/Arch/Host/FileSystem.cpp
@@ -27,6 +27,12 @@ struct FileDir {
 
 namespace Host
 {
+namespace
+{
+IFS::Host::FileSystem hostFileSystem;
+}
+IFileSystem& fileSystem{hostFileSystem};
+
 int FileSystem::getinfo(Info& info)
 {
 	return Error::NotImplemented;

--- a/src/Arch/Host/include/IFS/Host/FileSystem.h
+++ b/src/Arch/Host/include/IFS/Host/FileSystem.h
@@ -103,5 +103,7 @@ private:
 	void fillStat(const struct stat& s, FileStat& stat);
 };
 
+extern IFileSystem& fileSystem;
+
 } // namespace Host
 } // namespace IFS

--- a/src/SPIFFS/FileSystem.cpp
+++ b/src/SPIFFS/FileSystem.cpp
@@ -191,7 +191,7 @@ int FileSystem::check()
 {
 	fs.check_cb_f = [](spiffs* fs, spiffs_check_type type, spiffs_check_report report, u32_t arg1, u32_t arg2) {
 		if(report > SPIFFS_CHECK_PROGRESS) {
-			debug_i("SPIFFS check %d, %d, %u, %u", type, report, arg1, arg2);
+			debug_d("SPIFFS check %d, %d, %u, %u", type, report, arg1, arg2);
 		}
 	};
 
@@ -457,7 +457,7 @@ int FileSystem::flushMeta(File::Handle file)
 
 	// Changed ?
 	if(smb->meta.isDirty()) {
-		debug_i("Flushing Metadata to disk");
+		debug_d("Flushing Metadata to disk");
 		smb->meta.clearDirty();
 		int err = SPIFFS_fupdate_meta(handle(), file, smb);
 		if(err < 0) {

--- a/src/include/IFS/FileSystem.h
+++ b/src/include/IFS/FileSystem.h
@@ -35,7 +35,8 @@
 	XX(Mounted, "Filing system is mounted and in use")                                                                 \
 	XX(ReadOnly, "Writing not permitted to this volume")                                                               \
 	XX(Virtual, "Virtual filesystem, doesn't host files directly")                                                     \
-	XX(Check, "Volume check recommended")
+	XX(Check, "Volume check recommended")                                                                              \
+	XX(NoMeta, "Metadata unsupported")
 
 namespace IFS
 {

--- a/src/include/IFS/SPIFFS/FileSystem.h
+++ b/src/include/IFS/SPIFFS/FileSystem.h
@@ -45,9 +45,14 @@ namespace IFS
 {
 namespace SPIFFS
 {
+/// This number is made up, but serves to identify that metadata is valid
+static constexpr uint32_t metaMagic{0xE3457A77};
+
 /** @brief Content of SPIFFS metadata area
  */
 struct FileMeta {
+	// Magic
+	uint32_t magic;
 	// Modification time
 	time_t mtime;
 	// File::Attributes - default indicates content has changed
@@ -74,8 +79,12 @@ struct FileMeta {
 	}
 };
 
+#define SPIFFS_STORE_META (SPIFFS_OBJ_META_LEN >= 16)
+
 union SpiffsMetaBuffer {
-	uint8_t buffer[SPIFFS_OBJ_META_LEN] = {0};
+#if SPIFFS_STORE_META
+	uint8_t buffer[SPIFFS_OBJ_META_LEN]{0};
+#endif
 	FileMeta meta;
 };
 

--- a/test/fstest.hw
+++ b/test/fstest.hw
@@ -2,10 +2,6 @@
     "name": "FS Test",
     "base_config": "spiffs",
     "partitions": {
-        "spiffs0": {
-            "address": "0x100000",
-            "size": "1500K"
-        },
         "fwfs1": {
             "address": "0x280000",
             "size": "0x60000",

--- a/test/include/modules.h
+++ b/test/include/modules.h
@@ -1,3 +1,3 @@
 // List of test modules to register
 
-#define TEST_MAP(XX) XX(general)
+#define TEST_MAP(XX) XX(General)

--- a/test/modules/fstest.cpp
+++ b/test/modules/fstest.cpp
@@ -502,7 +502,7 @@ private:
 	Flags flags;
 };
 
-void REGISTER_TEST(general)
+void REGISTER_TEST(General)
 {
 	registerGroup<FsTest>();
 }

--- a/test/modules/fstest.cpp
+++ b/test/modules/fstest.cpp
@@ -69,7 +69,7 @@ using IFileSystem = IFS::IFileSystem;
 class FsTest : public TestGroup
 {
 public:
-	FsTest() : TestGroup(_F("IFS")), hostFileSys(gHostFileSystem)
+	FsTest() : TestGroup(_F("IFS"))
 	{
 	}
 
@@ -77,15 +77,15 @@ public:
 	{
 		Storage::Partition part;
 
-		auto file = hostFileSys.open(imgfile, File::Create | File::ReadWrite);
+		auto file = IFS::Host::fileSystem.open(imgfile, File::Create | File::ReadWrite);
 		if(file < 0) {
-			debug_e("Failed to open '%s': %s", imgfile.c_str(), hostFileSys.getErrorString(file).c_str());
+			debug_e("Failed to open '%s': %s", imgfile.c_str(), IFS::Host::fileSystem.getErrorString(file).c_str());
 		} else {
-			size_t curSize = hostFileSys.getSize(file);
+			size_t curSize = IFS::Host::fileSystem.getSize(file);
 			if(curSize < FFS_FLASH_SIZE) {
-				hostFileSys.truncate(file, FFS_FLASH_SIZE);
+				IFS::Host::fileSystem.truncate(file, FFS_FLASH_SIZE);
 			}
-			auto dev = new Storage::FileDevice(imgfile, hostFileSys, file);
+			auto dev = new Storage::FileDevice(imgfile, IFS::Host::fileSystem, file);
 			Storage::registerDevice(dev);
 			if(curSize < FFS_FLASH_SIZE) {
 				dev->erase_range(curSize, FFS_FLASH_SIZE - curSize);
@@ -415,7 +415,6 @@ public:
 		debug_i("check(): %s", getErrorString(fs, res).c_str());
 		scandir(fs, "");
 
-
 		flags[Flag::writeThroughTest] = false;
 		scandir(fs, "");
 	}
@@ -438,7 +437,7 @@ public:
 
 		Storage::Partition part;
 		if(imgfile) {
-			part = createFwfsPartition(hostFileSys, imgfile);
+			part = createFwfsPartition(IFS::Host::fileSystem, imgfile);
 		} else {
 			part = createFwfsPartition(fwfsImage1);
 		}
@@ -497,8 +496,6 @@ public:
 	}
 
 private:
-	IFS::Host::FileSystem gHostFileSystem;
-	IFileSystem& hostFileSys;
 	Flags flags;
 };
 


### PR DESCRIPTION
`SPIFFS_OBJ_META_LEN` defined as build variable to allow compatibility with existing images, or to extend size of metadata (e.g. for user storage)
Don't read or write metadata if defined meta length is < 16
Add magic to start of SPIFFS metadata, set dirty flag when initialised
Newly created metadata is automatically flushed to storage, but only if file is open in write mode
Add filesystem info attribute to indicate if metadata is supported
Fix block size assignment for SPIFFS
Define global `IFS::Host::fileSystem&` for easier use
