### PR TITLE
Fix handling of UTF8 filenames in FWFS builder

### DIFF
--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -174,7 +174,7 @@ int FileSystem::makedirs(const char* path)
 	while((i = s.indexOf('/', i)) > 0) {
 		s[i] = '\0';
 		int err = mkdir(s.c_str());
-		if(err < 0) {
+		if(err < 0 && err != Error::Exists) {
 			return err;
 		}
 		s[i++] = '/';

--- a/src/HostUtil.cpp
+++ b/src/HostUtil.cpp
@@ -69,6 +69,32 @@ int mapFlags(OpenFlags flags)
 	return ret;
 }
 
+int syserr()
+{
+	switch(errno) {
+	case EPERM:
+	case EACCES:
+		return Error::Denied;
+	case ENOMEM:
+		return Error::NoMem;
+	case ENOENT:
+		return Error::NotFound;
+	case ENFILE:
+	case EMFILE:
+		return Error::OutOfFileDescs;
+	case EFBIG:
+		return Error::TooBig;
+	case ENOSPC:
+		return Error::NoSpace;
+	case EROFS:
+		return Error::ReadOnly;
+	case EINVAL:
+		return Error::BadParam;
+	default:
+		return Error::fromSystem(-errno);
+	}
+}
+
 String getErrorString(int err)
 {
 	if(Error::isSystem(err)) {

--- a/src/HostUtil.cpp
+++ b/src/HostUtil.cpp
@@ -72,6 +72,8 @@ int mapFlags(OpenFlags flags)
 int syserr()
 {
 	switch(errno) {
+	case EEXIST:
+		return Error::Exists;
 	case EPERM:
 	case EACCES:
 		return Error::Denied;

--- a/src/include/IFS/Host/Util.h
+++ b/src/include/IFS/Host/Util.h
@@ -34,10 +34,7 @@ namespace IFS::Host
 /**
  * @brief Get IFS error code for the current system errno
  */
-inline int syserr()
-{
-	return Error::fromSystem(-errno);
-}
+int syserr();
 
 /**
  * @brief Get corresponding host flags for given IFS flags

--- a/test/files/A Subdirectory/CharactersÄÖÜß.txt
+++ b/test/files/A Subdirectory/CharactersÄÖÜß.txt
@@ -1,0 +1,1 @@
+UTF8 filename

--- a/tools/fsbuild/FWFS.py
+++ b/tools/fsbuild/FWFS.py
@@ -344,7 +344,11 @@ class NamedObject(Object16):
     def path(self):
         s = self.parent().path() + self.parent().pathsep() + self.name
         return s
-   
+
+    @property
+    def encoded_name(self):
+        return self.name.encode('utf-8')
+
     def findChild(self, name):
         for obj in self.__children:
             if obj.isNamed() and obj.name == name:
@@ -396,12 +400,12 @@ class NamedObject(Object16):
 
     def contentSize(self):
         # temporary: children are all references
-        return 5 + len(self.name) + self.childTableSize()
+        return 5 + len(self.encoded_name) + self.childTableSize()
         
     # Fetch the content - must be called after object indices have been assigned
     def content(self):
-        s = struct.pack("<BL", len(self.name), round(self.mtime))
-        s += self.name.encode()
+        s = struct.pack("<BL", len(self.encoded_name), round(self.mtime))
+        s += self.encoded_name
         s += self.childTable()
         return s
 


### PR DESCRIPTION
Builder produces invalid structures if filename contains UTF8-encoded characters.